### PR TITLE
Add single-file worker and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,5 @@ Telegram ↔ Cloudflare Workers ↔ OpenAI Assistants (threads + KV)
    ```
 3. Set Telegram webhook to the URL printed by `wrangler`.
 
-## Deployment
-1. In the Cloudflare Dashboard create a KV namespace and bind it to the worker as `THREADS`.
-2. Add secrets `TELEGRAM_TOKEN`, `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` in *Workers → Settings → Variables*.
-3. Deploy:
-   ```sh
-   npm run deploy
-   ```
-4. Point the Telegram webhook to the deployed worker URL.
+## Deploy
+Открой Cloudflare → Workers & Pages → tg-assistant-worker → Edit code → вставь worker.js → Save & Deploy

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,72 @@
+// Telegram ↔ OpenAI Assistants on Cloudflare Workers (single-file)
+async function tg(method, token, payload) {
+  return fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+async function typing(token, chatId) { await tg("sendChatAction", token, { chat_id: chatId, action: "typing" }); }
+async function sendText(token, chatId, text) { await tg("sendMessage", token, { chat_id: chatId, text }); }
+
+async function ai(env, path, init = {}) {
+  return fetch(`https://api.openai.com/v1/${path}`, {
+    method: init.method || (init.body ? "POST" : "GET"),
+    headers: { authorization: `Bearer ${env.OPENAI_API_KEY}`, "content-type": "application/json" },
+    body: init.body ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+async function getThreadId(kv, chatId) { return kv.get(`thread:${chatId}`); }
+async function setThreadId(kv, chatId, threadId) { await kv.put(`thread:${chatId}`, threadId); }
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    const p = url.pathname.split("/").filter(Boolean);
+    if (p[0] !== "webhook" || p[1] !== env.WEBHOOK_SECRET) return new Response("Not found", { status: 404 });
+    if (req.method !== "POST") return new Response("OK");
+
+    const update = await req.json().catch(()=> ({}));
+    const msg = update.message || update.edited_message || update.callback_query?.message;
+    const chatId = msg?.chat?.id;
+    if (!chatId) return new Response("OK");
+
+    await typing(env.TELEGRAM_TOKEN, chatId);
+
+    const text = msg?.text ?? msg?.caption;
+    if (!text) { await sendText(env.TELEGRAM_TOKEN, chatId, "Понимаю только текст. Пришлите сообщение текстом 🙌"); return new Response("OK"); }
+
+    let threadId = await getThreadId(env.KV, chatId);
+    if (!threadId) {
+      const tRes = await ai(env, "threads", { body: {} });
+      const tJson = await tRes.json(); threadId = tJson?.id;
+      if (!threadId) { await sendText(env.TELEGRAM_TOKEN, chatId, "Не смог создать тред. Попробуйте позже."); return new Response("OK"); }
+      await setThreadId(env.KV, chatId, threadId);
+    }
+
+    await ai(env, `threads/${threadId}/messages`, { body: { role: "user", content: text } });
+    const runRes = await ai(env, `threads/${threadId}/runs`, { body: { assistant_id: env.ASSISTANT_ID } });
+    const run = await runRes.json();
+    if (!run?.id) { await sendText(env.TELEGRAM_TOKEN, chatId, "Ошибка запуска ассистента. Попробуйте ещё раз."); return new Response("OK"); }
+
+    for (let i=0;i<45;i++){
+      const st = await (await ai(env, `threads/${threadId}/runs/${run.id}`)).json();
+      if (st.status === "completed") break;
+      if (["failed","cancelled","expired"].includes(st.status)) { await sendText(env.TELEGRAM_TOKEN, chatId, "Упс, не смог ответить. Попробуйте ещё раз."); return new Response("OK"); }
+      if (i%5===0) await typing(env.TELEGRAM_TOKEN, chatId);
+      await sleep(1000);
+    }
+
+    const mJson = await (await ai(env, `threads/${threadId}/messages?order=desc&limit=10`)).json();
+    const assistantMsg = (mJson.data||[]).find(m=>m.role==="assistant");
+    let out = "…";
+    if (assistantMsg?.content?.length){
+      const parts = assistantMsg.content.filter(c=>c.type==="text");
+      out = parts.map(p=>p.text?.value||"").join("\n\n").trim() || "…";
+    }
+    await sendText(env.TELEGRAM_TOKEN, chatId, out);
+    return new Response("OK");
+  }
+};


### PR DESCRIPTION
## Summary
- add `worker.js` single-file Cloudflare worker for Telegram ↔ OpenAI Assistants
- document manual deployment via Cloudflare dashboard

## Testing
- `npm test` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_68ab229392c88327bef186589f6b6136